### PR TITLE
fix: use correct ENV variables

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -5,7 +5,7 @@ import Layout from './src/components/Layout'
 
 export const wrapRootElement = ({ element }) => {
   return (
-    <ShopkitProvider clientId="EdP3Gi1agyUF3yFS7Ngm8iyodLgbSR3wY4ceoJl0d2">
+    <ShopkitProvider clientId={process.env.GATSBY_MOLTIN_CLIENT_ID}>
       {element}
     </ShopkitProvider>
   )

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -34,7 +34,7 @@ module.exports = {
     {
       resolve: '@moltin/gatsby-source-moltin',
       options: {
-        client_id: process.env.MOLTIN_CLIENT_ID,
+        client_id: process.env.GATSBY_MOLTIN_CLIENT_ID,
         flows: {
           product: [
             'meta_title',

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -5,7 +5,7 @@ import Layout from './src/components/Layout'
 
 export const wrapRootElement = ({ element }) => {
   return (
-    <ShopkitProvider clientId="EdP3Gi1agyUF3yFS7Ngm8iyodLgbSR3wY4ceoJl0d2">
+    <ShopkitProvider clientId={process.env.GATSBY_MOLTIN_CLIENT_ID}>
       {element}
     </ShopkitProvider>
   )

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,5 +4,5 @@
   command = "yarn build"
 
 [template.environment]
-  MOLTIN_CLIENT_ID = "Your Moltin client ID"
-  STRIPE_PUBLISHABLE_KEY = "Your publishable key"
+  GATSBY_MOLTIN_CLIENT_ID = "Your Moltin client ID"
+  GATSBY_STRIPE_PUBLISHABLE_KEY = "Your publishable key"


### PR DESCRIPTION
In order to expose the `MOLTIN_CLIENT_ID` to the client-side, in Gatsby we must prefix them with `GATSBY_`.