### PR TITLE
fix: Disable Algolia search in Gatsby to pass Netlify builds

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -47,63 +47,63 @@ module.exports = {
       }
     },
     'gatsby-plugin-stripe',
-    {
-      resolve: `gatsby-plugin-algolia`,
-      options: {
-        appId: process.env.GATSBY_ALGOLIA_APP_ID,
-        apiKey: process.env.ALGOLIA_ADMIN_KEY,
-        queries: [
-          {
-            query: `
-            {
-              allMoltinProduct {
-                nodes {
-                  objectID: id
-                  name
-                  slug
-                  imgUrl: mainImageHref
-                  meta {
-                    display_price {
-                      with_tax {
-                        formatted
-                      }
-                    }
-                  }
-                  categories {
-                    name
-                  }
-                  brands {
-                    name
-                  }
-                  collections {
-                    name
-                  }
-                }
-              }
-            }
-          `,
-            transformer: ({
-              data: {
-                allMoltinProduct: { nodes }
-              }
-            }) =>
-              nodes.map(
-                ({ meta, categories, brands, collections, ...rest }) => ({
-                  ...rest,
-                  price: meta.display_price.with_tax.formatted,
-                  categories: categories
-                    ? categories.map(({ name }) => name)
-                    : [],
-                  brands: brands ? brands.map(({ name }) => name) : [],
-                  collections: collections
-                    ? collections.map(({ name }) => name)
-                    : []
-                })
-              ),
-            indexName: process.env.GATSBY_ALGOLIA_INDEX_NAME
-          }
-        ]
-      }
-    }
+    // {
+    //   resolve: `gatsby-plugin-algolia`,
+    //   options: {
+    //     appId: process.env.GATSBY_ALGOLIA_APP_ID,
+    //     apiKey: process.env.ALGOLIA_ADMIN_KEY,
+    //     queries: [
+    //       {
+    //         query: `
+    //         {
+    //           allMoltinProduct {
+    //             nodes {
+    //               objectID: id
+    //               name
+    //               slug
+    //               imgUrl: mainImageHref
+    //               meta {
+    //                 display_price {
+    //                   with_tax {
+    //                     formatted
+    //                   }
+    //                 }
+    //               }
+    //               categories {
+    //                 name
+    //               }
+    //               brands {
+    //                 name
+    //               }
+    //               collections {
+    //                 name
+    //               }
+    //             }
+    //           }
+    //         }
+    //       `,
+    //         transformer: ({
+    //           data: {
+    //             allMoltinProduct: { nodes }
+    //           }
+    //         }) =>
+    //           nodes.map(
+    //             ({ meta, categories, brands, collections, ...rest }) => ({
+    //               ...rest,
+    //               price: meta.display_price.with_tax.formatted,
+    //               categories: categories
+    //                 ? categories.map(({ name }) => name)
+    //                 : [],
+    //               brands: brands ? brands.map(({ name }) => name) : [],
+    //               collections: collections
+    //                 ? collections.map(({ name }) => name)
+    //                 : []
+    //             })
+    //           ),
+    //         indexName: process.env.GATSBY_ALGOLIA_INDEX_NAME
+    //       }
+    //     ]
+    //   }
+    // }
   ]
 }


### PR DESCRIPTION
## Type

* ### Feature
  <!--Implements a new feature-->
* ### Fix
  - Disable Algolia search in Gatsby to pass builds
  - Will re-enable upon creation of new Algolia account
* ### Docs
  <!--Documentation only changes-->
* ### Style
  <!--Changes that **do not** affect the meaning of the code (white-space, formatting, missing semi-colons, etc)-->
* ### Refactor
  <!--A code change that neither fixes a bug nor adds a feature-->
* ### Performance
  <!--A code change that improves performance-->
* ### Test
  <!--Adding missing or correcting existing tests-->
* ### Chore
  <!--Changes to the build process or auxiliary tools and libraries such as documentation generation-->

## Description

<!--A brief description of changes. Things to include: WIP? Dependent PR's opened against other tickets?-->

## Issues

<!--A list of Jira issues closed by this PR.-->

 * N/A

## Dependencies

<!--Other PRs or builds that this PR depends on.-->

## Notes

<!--Any additional notes.-->
