### PR TITLE
[Fix] sort by for algolia search and collection error

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -69,6 +69,9 @@ module.exports = {
                       }
                     }
                   }
+                  price {
+                    amount
+                  }
                   categories {
                     name
                   }
@@ -88,7 +91,7 @@ module.exports = {
               }
             }) =>
               nodes.map(
-                ({ meta, categories, brands, collections, ...rest }) => ({
+                ({ meta, categories, brands, collections, price, ...rest }) => ({
                   ...rest,
                   price: meta.display_price.with_tax.formatted,
                   categories: categories
@@ -97,7 +100,10 @@ module.exports = {
                   brands: brands ? brands.map(({ name }) => name) : [],
                   collections: collections
                     ? collections.map(({ name }) => name)
-                    : []
+                    : [],
+                  amount: price
+                  ? price[0].amount
+                  : null,
                 })
               ),
             indexName: process.env.GATSBY_ALGOLIA_INDEX_NAME

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -120,7 +120,7 @@ exports.createPages = async ({ graphql, actions: { createPage } }) => {
     ({ node: { id, slug, products: items } }) => {
       paginate({
         createPage,
-        items,
+        items: items || [],
         itemsPerPage,
         pathPrefix: `/categories/${slug}`,
         component: path.resolve('src/templates/CategoryPage.js'),

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -27,8 +27,8 @@ function SearchPage() {
                 defaultRefinement={indexName}
                 items={[
                   { value: indexName, label: 'Featured' },
-                  { value: 'product_price_asc', label: 'Price asc.' },
-                  { value: 'product_price_desc', label: 'Price desc.' }
+                  { value: `${indexName}_price_asc`, label: 'Price asc.' },
+                  { value: `${indexName}_price_desc`, label: 'Price desc.' }
                 ]}
               />
             </div>


### PR DESCRIPTION
## Type
* ### Fix
  <!--Fixes a bug-->

## Description

<!--A brief description of changes. Things to include: WIP? Dependent PR's opened against other tickets?-->
Fixes the following issues:
- Changes the sort by to use the name of the Algolia index instead of hardcoding it to `product`
- fixes issue with collection that would throw error if collection contained less products number of product per page.
- Adds `amount` attribute to Algolia index. This is used for sorting, since Algolia can only sort attributes that are numbers or boolean. 

