### PR TITLE
Adds multi-level category navigation support

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -9,6 +9,8 @@ function IndexPage({
     categories: { edges: categories }
   }
 }) {
+  const topCategories = categories.filter(cat => !cat.node.relationships.parent);
+
   return (
     <>
       <div className="hero overflow-y-hidden overflow-x-hidden front-banner">
@@ -33,9 +35,9 @@ function IndexPage({
         </div>
       </div>
 
-      {categories && (
+      {topCategories && (
         <div className="flex flex-wrap -mx-6">
-          {categories.map(({ node }) => (
+          {topCategories.map(({ node }) => (
             <Category key={node.id} {...node} />
           ))}
         </div>
@@ -60,6 +62,18 @@ export const query = graphql`
                 fluid(maxWidth: 560) {
                   ...GatsbyImageSharpFluid
                 }
+              }
+            }
+          }
+          relationships {
+            children {
+              data {
+                id
+              }
+            }
+            parent {
+              data {
+                id
               }
             }
           }

--- a/src/templates/CategoryPage.js
+++ b/src/templates/CategoryPage.js
@@ -5,14 +5,17 @@ import SEO from '../components/SEO'
 import PageTitle from '../components/PageTitle'
 import ProductGrid from '../components/ProductGrid'
 import Pagination from '../components/Pagination'
+import Category from '../components/Category'
 
-function CategoryPage({ data: { category, products }, pageContext }) {
+function CategoryPage({ data: { category, categories : { edges: categories }, products }, pageContext }) {
   const {
     humanPageNumber,
     numberOfPages,
     nextPagePath,
     previousPagePath
   } = pageContext
+
+  const childCategories = category.relationships.children && category.relationships.children.data.map(child => categories.find(cat => cat.node.id === child.id));
 
   return (
     <>
@@ -22,6 +25,13 @@ function CategoryPage({ data: { category, products }, pageContext }) {
       />
 
       <PageTitle title={category.name} description={category.description} />
+      {childCategories && (
+        <div className="flex flex-wrap -mx-6">
+          {childCategories.map(({ node }) => (
+            <Category key={node.id} {...node} />
+          ))}
+        </div>
+      )}
       <ProductGrid products={products.nodes} />
       <Pagination
         currentPage={humanPageNumber}
@@ -43,6 +53,39 @@ export const query = graphql`
       slug
       name
       description
+      relationships {
+        children {
+          data {
+            id
+          }
+        }
+        parent {
+          data {
+            id
+          }
+        }
+      }
+    }
+
+    categories: allMoltinCategory {
+      edges {
+        node {
+          id
+          name
+          slug
+          description
+          products {
+            name
+            mainImage {
+              childImageSharp {
+                fluid(maxWidth: 560) {
+                  ...GatsbyImageSharpFluid
+                }
+              }
+            }
+          }
+        }
+      }
     }
 
     products: allMoltinProduct(


### PR DESCRIPTION
## Type

* ### Feature
  <!--Implements a new feature-->

## Description

<!--A brief description of changes. Things to include: WIP? Dependent PR's opened against other tickets?-->
Adds multi-level category navigation support, with the index page only showing top level categories, and category pages showing child categories if there are any.

Example screenshots:
Index page
![image](https://user-images.githubusercontent.com/50891790/85338414-1db9d200-b497-11ea-835b-8b8dd6a01dc5.png)
In a top level category with children
![image](https://user-images.githubusercontent.com/50891790/85338540-4f329d80-b497-11ea-9d04-eda00788cea2.png)
